### PR TITLE
Update translate.image to accept blob directly.

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,5 +1,5 @@
 {
   "name": "@jigsawstack/jigsawstack",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "exports": "./index.ts"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": ["framework", "ai", "nextjs", "react"],
   "type": "module",
   "license": "MIT",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "homepage": "https://jigsawstack.com",
   "repository": {
     "type": "git",

--- a/src/general/index.ts
+++ b/src/general/index.ts
@@ -31,7 +31,14 @@ class General {
       }
       return await this.client.fetchJSS("/ai/translate", "POST", params);
     },
-    image: async (params: TranslateImageParams) => {
+    image: async (
+      params: Blob | Buffer | TranslateImageParams,
+      options?: Omit<TranslateImageParams, "file_store_key" | "url">
+    ): Promise<ReturnType<typeof respToFileChoice>> => {
+      if (params instanceof Blob || params instanceof Buffer) {
+        const resp: Response = await this.client.fetchJSS("/ai/translate/image", "POST", params, options);
+        return respToFileChoice(resp);
+      }
       const resp: Response = await this.client.fetchJSS("/ai/translate/image", "POST", params);
       return respToFileChoice(resp);
     },


### PR DESCRIPTION
Updated translate.image to now accept blob directly, or params otherwise. 82e4e6592bea161c48a7fbab6abd1a3a3f300d98

```javascript
import { JigsawStack } from "jigsawstack";
import fs from "fs";

const jigsaw = JigsawStack({ apiKey: "your-api-key" });
const imageBuffer = fs.readFileSync("capture.png");
const response = await jigsaw.translate.image(imageBuffer, {
  target_language: "es"
});

console.log(response);
```

console log:
```bash
translation:  {
  blob: [Function: blob],
  buffer: [AsyncFunction: buffer],
  file: [AsyncFunction: file]
}
```