### PR TITLE
Update route for object_detection to match OCR

### DIFF
--- a/src/vision/vision.ts
+++ b/src/vision/vision.ts
@@ -6,7 +6,7 @@ class Vision {
     return await this.client.fetchJSS("/vocr", "POST", params);
   };
   object_detection = async (params: ObjectDetectionParams): Promise<ObjectDetectionResponse> => {
-    return await this.client.fetchJSS("/ai/object_detection", "POST", params);
+    return await this.client.fetchJSS("/object_detection", "POST", params);
   };
 }
 


### PR DESCRIPTION
This pull request updates endpoint paths in the object_detection methods of the jigsawstack/vision.py file to remove the /ai prefix. 