### PR TITLE
update embedding v2 snake case

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -46,7 +46,7 @@ export const JigsawStack = (config?: BaseConfig) => {
     prediction: general.prediction,
     text_to_sql: general.text_to_sql,
     embedding: general.embedding,
-    embeddingV2: general.embeddingV2,
+    embedding_v2: general.embedding_v2,
     audio,
     vision: {
       vocr: createBoundMethod(vision, vision.vocr),

--- a/src/general/index.ts
+++ b/src/general/index.ts
@@ -26,7 +26,7 @@ class General {
     this.client = client;
     this.summary = this.summary.bind(this);
     this.embedding = this.embedding.bind(this);
-    this.embeddingV2 = this.embeddingV2.bind(this);
+    this.embedding_v2 = this.embedding_v2.bind(this);
   }
 
   translate = {
@@ -88,9 +88,9 @@ class General {
     return await this.client.fetchJSS("/v1/embedding", "POST", params);
   }
 
-  embeddingV2(params: EmbeddingV2Params): Promise<EmbeddingV2Response>;
-  embeddingV2(file: Blob | Buffer, params: Omit<EmbeddingV2Params, "url" | "file_store_key" | "file_content">): Promise<EmbeddingV2Response>;
-  async embeddingV2(params: EmbeddingV2Params | Blob | Buffer, options?: EmbeddingV2Params): Promise<EmbeddingV2Response> {
+  embedding_v2(params: EmbeddingV2Params): Promise<EmbeddingV2Response>;
+  embedding_v2(file: Blob | Buffer, params: Omit<EmbeddingV2Params, "url" | "file_store_key" | "file_content">): Promise<EmbeddingV2Response>;
+  async embedding_v2(params: EmbeddingV2Params | Blob | Buffer, options?: EmbeddingV2Params): Promise<EmbeddingV2Response> {
     if (params instanceof Blob || params instanceof Buffer) {
       const formData = createFileUploadFormData(params, options);
       return await this.client.fetchJSS("/v2/embedding", "POST", formData);


### PR DESCRIPTION
This pull request standardizes the naming convention for the embedding V2 method across the codebase by renaming `embeddingV2` to `embedding_v2`. This change ensures consistency and clarity in both method definitions and usage.

Naming consistency improvements:

* Renamed the method `embeddingV2` to `embedding_v2` in the `General` class, including all overloads and the implementation, in `src/general/index.ts`.
* Updated the binding in the `General` class constructor to use the new `embedding_v2` method name in `src/general/index.ts`.
* Changed the property name from `embeddingV2` to `embedding_v2` in the returned object of the `JigsawStack` function in `src/core.ts`.