### PR TITLE
now takes object instead of object detection

### DIFF
--- a/src/vision/interfaces.ts
+++ b/src/vision/interfaces.ts
@@ -32,7 +32,7 @@ export type ObjectDetectionParams = {
   url?: string;
   file_store_key?: string;
   prompts?: string[];
-  features?: ("object_detection" | "gui")[];
+  features?: ("object" | "gui")[];
   annotated_image?: boolean;
   return_type?: "url" | "base64";
   return_masks?: boolean;

--- a/tests/vision.test.ts
+++ b/tests/vision.test.ts
@@ -466,7 +466,7 @@ describe("Object Detection API", () => {
   test("should work with object_detection feature", async () => {
     const result = await client.vision.object_detection({
       url: TEST_URLS.image,
-      features: ["object_detection"],
+      features: ["object"],
     });
 
     expectSuccess(result);
@@ -506,7 +506,7 @@ describe("Object Detection API", () => {
   test("should work with both object_detection and gui features", async () => {
     const result = await client.vision.object_detection({
       url: TEST_URLS.image,
-      features: ["object_detection", "gui"],
+      features: ["object", "gui"],
     });
 
     expectSuccess(result);
@@ -727,7 +727,7 @@ describe("Object Detection API", () => {
     const result = await client.vision.object_detection({
       url: TEST_URLS.image,
       prompts: ["detect all objects", "find text elements"],
-      features: ["object_detection", "gui"],
+      features: ["object", "gui"],
       annotated_image: true,
       return_type: "url",
     });


### PR DESCRIPTION
This pull request makes a small change to the `ObjectDetectionParams` type in `src/vision/interfaces.ts`, updating the possible values for the `features` property to use `"object"` instead of `"object_detection"`.

** Please merge only after main has the object as feature supported**